### PR TITLE
Add streaming PubMed

### DIFF
--- a/llm/convert_pubmed.py
+++ b/llm/convert_pubmed.py
@@ -1,0 +1,44 @@
+import os
+import json
+from torch.utils.data import IterableDataset, DataLoader, get_worker_info
+from composer.datasets.streaming import StreamingDatasetWriter
+
+class PubmedDataset(IterableDataset):
+  def __init__(self, split, start, end):
+    self.urls = [
+      f'./pubmed_randomized/pubmedRandomized_{split}.{i}-of-{end}.jsonl' for i in range(start, end+1)
+    ]
+
+  def __iter__(self):
+    worker_info = get_worker_info()
+    if worker_info:
+      num_workers = worker_info.num_workers
+      worker_id = worker_info.id
+      assert len(self.urls) % num_workers == 0
+      self.urls = self.urls[worker_id::num_workers] 
+    for url in self.urls:
+      with open(url) as f:
+        for line in f.readlines():
+          data = json.loads(line)
+          yield data["text"]
+
+def get_samples(split):
+  if split == 'train':
+    start, end = 1, 128
+  else:
+    start, end = 1, 8
+  ds = PubmedDataset(split=split, start=start, end=end)  
+  loader = DataLoader(ds, num_workers=min(end, 64), batch_size=512, prefetch_factor=2, drop_last=False)
+  for batch in loader: 
+    for sample in batch:
+      yield {'text': sample.encode('utf-8')}
+
+
+for split in ['val', 'train']:
+  with StreamingDatasetWriter(
+    dirname=os.path.join('./mds_pubmed_randomized', split),
+    fields=['text'],
+    shard_size_limit=(1 << 28),
+    compression=None
+  ) as out:
+    out.write_samples(samples=get_samples(split), use_tqdm=True, total=(18144581 if split == 'train' else 35677))

--- a/llm/llm/data_pubmed.py
+++ b/llm/llm/data_pubmed.py
@@ -1,0 +1,181 @@
+import os
+import sys
+from itertools import islice
+from typing import Any, Dict, Iterator, Mapping, Optional
+
+import transformers
+from composer.datasets.streaming import StreamingDataset
+from torch.utils.data import DataLoader
+
+
+class StreamingPubmed(StreamingDataset):
+    def __init__(self,
+                 remote: str,
+                 local: str,
+                 split: str,
+                 shuffle: bool,
+                 tokenizer_name: str,
+                 max_seq_len: int,
+                 group_method: str = 'truncate',
+                 max_retries: int = 2,
+                 timeout: float = 120,
+                 batch_size: Optional[int] = None):
+        if group_method not in ['truncate', 'concat']:
+            raise ValueError(f"group_method='{group_method}' must be one of ['truncate', 'concat'].")
+
+        # Build StreamingDataset
+        decoders = {
+            'text': self._decode,
+        }
+        super().__init__(remote=os.path.join(remote, split),
+                         local=os.path.join(local, split),
+                         shuffle=shuffle,
+                         decoders=decoders,
+                         max_retries=max_retries,
+                         timeout=timeout,
+                         batch_size=batch_size)
+        self.tokenizer_name = tokenizer_name
+        self.max_seq_len = max_seq_len
+        self.group_method = group_method
+
+        # Build tokenizer
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(self.tokenizer_name)
+        if self.tokenizer.pad_token is None:
+            # Some tokenizers (e.g. GPT2 tokenizer) have no padding token which causes bugs
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        # suppress warnings when using group_method='concat' and no truncation
+        self.tokenizer.model_max_length = int(1e30)
+
+    # How to decode binary data from .mds files to python strings
+    def _decode(self, data: bytes) -> str:
+        return data.decode('utf-8')
+
+    # How to tokenize a text sample to a token sample
+    def _tokenize(self, text_sample):
+        if self.group_method == 'truncate':
+            truncation = True
+            padding = 'max_length'
+            max_length = self.max_seq_len
+        elif self.group_method == 'concat':
+            truncation = False
+            padding = False
+            max_length = None
+        else:
+            raise ValueError(f"Got unknown group_method='{self.group_method}'.")
+        return self.tokenizer(text_sample['text'], truncation=truncation, padding=padding, max_length=max_length)
+
+    # How to process a sample
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        text_sample = super().__getitem__(idx)
+        token_sample = self._tokenize(text_sample)
+        return token_sample
+
+    # Define iterable over samples
+    # Usually this can be left alone and inherited directly from super() class StreamingDataset, but concatenating samples is custom behavior.
+    # If group_method=='truncate', we simply return the token sample.
+    # If group_method=='concat', then we keep fetching token samples until we fill up max_seq_len.
+    def __iter__(self) -> Iterator[Any]:
+        if self.group_method == 'truncate':
+            iterator = super().__iter__()
+            yield from iterator
+
+        elif self.group_method == 'concat':
+            buffer = {}
+            while True:
+                iterator = super().__iter__()
+                for sample in iterator:
+
+                    for k, v in sample.items():
+                        buffer[k] = buffer.get(k, []) + v + [self.tokenizer.eos_token_id]
+                    if len(buffer['input_ids']) >= self.max_seq_len:
+                        concat_sample = {}
+                        for k, v in buffer.items():
+                            concat_sample[k] = v[:self.max_seq_len]
+                            buffer[k] = v[self.max_seq_len:]
+                        yield concat_sample
+        else:
+            raise ValueError(f"Got unknown group_method='{self.group_method}'.")
+
+    # Define length
+    # Usually this can be left alone and inherited directly from super() class StreamingDataset, but concatenating samples is custom behavior.
+    # If group_method=='truncate', we simply return the # samples.
+    # If group_method=='concat', we repeat forever, and we don't have a defined length.
+    def __len__(self) -> int:
+        if self.group_method == 'truncate':
+            return super().__len__()
+        elif self.group_method == 'concat':
+            return None
+        else:
+            raise ValueError(f"Got unknown group_method='{self.group_method}'.")
+
+
+def build_dataloader(cfg: Mapping[str, Any], device_batch_size: int):
+
+    if cfg.dataset.name == 'streaming_pubmed':
+        dataset = StreamingPubmed(split=cfg.dataset.split,
+                              remote=cfg.dataset.remote,
+                              local=cfg.dataset.local,
+                              shuffle=cfg.dataset.shuffle,
+                              tokenizer_name=cfg.dataset.tokenizer_name,
+                              max_seq_len=cfg.dataset.max_seq_len,
+                              group_method=cfg.dataset.group_method,
+                              batch_size=device_batch_size)
+    else:
+        raise ValueError(f'Not sure how to build dataset={cfg.dataset.name}')
+
+    collate_fn = transformers.DataCollatorForLanguageModeling(
+        tokenizer=dataset.tokenizer, mlm=False)
+
+    return DataLoader(
+        dataset,
+        collate_fn=collate_fn,
+        batch_size=device_batch_size,
+        drop_last=cfg.drop_last,
+        num_workers=cfg.num_workers,
+        pin_memory=cfg.pin_memory,
+        prefetch_factor=cfg.prefetch_factor,
+        persistent_workers=cfg.persistent_workers,
+        timeout=cfg.timeout,
+    )
+
+
+# Helpful to test if your dataloader is working locally
+# Run `python data.py [remote] [local, optional]` and verify that batches are printed out
+if __name__ == '__main__':
+    remote = sys.argv[1]
+    if len(sys.argv) > 2:
+        local = sys.argv[2]
+    else:
+        local = remote
+    print (f'Reading val split from {remote} -> {local}')
+
+    batch_size = 2
+    dataset  = StreamingPubmed(split='val',
+                            remote=remote,
+                            local=local,
+                            shuffle=False,
+                            tokenizer_name='gpt2',
+                            max_seq_len=32,
+                            group_method='truncate',
+                            batch_size=batch_size)
+    print (f'n_samples={len(dataset)}')
+
+    collate_fn = transformers.DataCollatorForLanguageModeling(
+        tokenizer=dataset.tokenizer, mlm=False)
+
+    loader = DataLoader(
+        dataset,
+        collate_fn=collate_fn,
+        batch_size=batch_size,
+        drop_last=False,
+        num_workers=4,
+    )
+
+    for batch_ix, batch in enumerate(islice(loader, 5)):
+        print('\n')
+        print ('#'*20, f'Batch {batch_ix}', '#'*20)
+        for k, v in batch.items():
+            print (k, v.shape, v.dtype)
+        for sample_ix, token_sample in enumerate(batch['input_ids']):
+            print ('-'*20, f' Sample {sample_ix} ', '-'*20)
+            print (dataset.tokenizer.decode(token_sample))

--- a/llm/llm/gpt.py
+++ b/llm/llm/gpt.py
@@ -84,8 +84,8 @@ class GPTBlock(nn.Module):
             raise ValueError(f'Unknown attn_impl={cfg.attn_impl}')
         self.ln_2 = nn.LayerNorm(cfg.d_model, device=device)
         self.mlp = GPTMLP(cfg, device=device)
-        self.resid_attn_dropout = nn.Dropout(cfg.resid_pdrop)
-        self.resid_mlp_dropout = nn.Dropout(cfg.resid_pdrop)
+        self.resid_attn_dropout = nn.Dropout(cfg.resid_pdrop, inplace=True)
+        self.resid_mlp_dropout = nn.Dropout(cfg.resid_pdrop, inplace=True)
 
     def forward(self,
                 x: torch.Tensor,
@@ -107,7 +107,7 @@ class GPT(nn.Module):
             dict(
                 wte=nn.Embedding(cfg.vocab_size, cfg.d_model, device=device),
                 wpe=nn.Embedding(cfg.max_seq_len, cfg.d_model, device=device),
-                emb_drop=nn.Dropout(cfg.emb_pdrop),
+                emb_drop=nn.Dropout(cfg.emb_pdrop, inplace=True),
                 blocks=nn.ModuleList([
                     GPTBlock(cfg, device=device) for _ in range(cfg.n_layers)
                 ]),

--- a/llm/main.py
+++ b/llm/main.py
@@ -14,7 +14,7 @@ from composer.optim.scheduler import (ConstantWithWarmupScheduler,
 from composer.utils import S3ObjectStore, dist, reproducibility
 from omegaconf import OmegaConf as om
 
-from llm.data import build_dataloader
+from llm.data_pubmed import build_dataloader
 from llm.gpt import ComposerGPT
 
 

--- a/llm/main.py
+++ b/llm/main.py
@@ -136,8 +136,11 @@ def main(cfg):
     if load_object_store is not None:
         name = list(load_object_store.keys())[0]
         kwargs = load_object_store[name]
-        load_object_store = build_object_store(name, kwargs)
-
+        if name in ['s3']:
+          load_object_store = build_object_store(name, kwargs)
+        elif name in ['wandb']:
+          load_object_store = build_logger(name, kwargs)
+    
     # Build the Trainer
     trainer = Trainer(
         run_name=cfg.get('run_name', os.environ['COMPOSER_RUN_NAME']),
@@ -158,6 +161,8 @@ def main(cfg):
         checkpoint_save_path=cfg.get('checkpoint_save_path', None),
         checkpoint_save_interval=cfg.get('checkpoint_save_interval', '1000ba'),
         num_checkpoints_to_keep=cfg.get('num_checkpoints_to_keep', -1),
+        save_artifact_name=cfg.get('save_artifact_name', '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt'),
+        save_latest_artifact_name=cfg.get('save_latest_artifact_name', '{run_name}/checkpoints/latest-rank{rank}'),
         load_path=cfg.get('load_path', None),
         load_object_store=load_object_store,
         load_weights_only=cfg.get('load_weights_only', False),

--- a/llm/yamls/gpt-125m-demo.yaml
+++ b/llm/yamls/gpt-125m-demo.yaml
@@ -1,5 +1,7 @@
-data_remote: &data_remote ./my-copy-c4
-data_local: &data_local ./my-copy-c4
+#data_remote: &data_remote ./my-copy-c4
+data_remote: &data_remote s3://crfm-pubmed/pubmed-randomized
+#data_local: &data_local ./my-copy-c4
+data_local: &data_local /tmp/mds-cache/pubmed-randomized
 max_seq_len: &max_seq_len 2048
 tokenizer_name: &tokenizer_name gpt2
 
@@ -24,7 +26,7 @@ model:
 # Dataloaders
 train_loader:
   dataset:
-    name: streaming_c4
+    name: streaming_pubmed
     remote: *data_remote
     local: *data_local
     split: val
@@ -41,7 +43,7 @@ train_loader:
 
 eval_loader:
   dataset:
-    name: streaming_c4
+    name: streaming_pubmed
     remote: *data_remote
     local: *data_local
     split: val

--- a/llm/yamls/gpt-125m-demo.yaml
+++ b/llm/yamls/gpt-125m-demo.yaml
@@ -6,7 +6,7 @@ max_seq_len: &max_seq_len 2048
 tokenizer_name: &tokenizer_name gpt2
 
 # Run Name
-run_name: gpt-125m
+run_name: mosaicml-fsdp-flash-attention-demo-1
 
 # Model
 model:
@@ -80,7 +80,7 @@ grad_clip_norm: 1.0
 
 # System
 seed: 17
-device_train_microbatch_size: 16
+device_train_microbatch_size: 8 # Hitting memory limits with 16 when resuming a run :(
 precision: bf16
 
 # FSDP
@@ -104,7 +104,6 @@ loggers:
   wandb: 
     entity: stanford-mercury
     project: mosaic-gpt2
-    name: "mosaicml-fsdp-flash-attention-demo-1"
     log_artifacts: true
         
 
@@ -112,6 +111,17 @@ loggers:
 checkpoint_save_path: './{run_name}/checkpoints'
 checkpoint_save_interval: 20000ba
 num_checkpoints_to_keep: 1  # Important, this cleans up checkpoints saved to DISK
+
+# WandB specific naming
+save_artifact_name: "{run_name}.pt"
+save_latest_artifact_name: "{run_name}.latest"
+
+# # Load from a WandB Artifact
+# load_path: mosaicml-fsdp-flash-attention-demo-1.pt:ep0-ba30
+# load_object_store:
+#   wandb:
+#     entity: stanford-mercury
+#     project: mosaic-gpt2
 
 # # Load from local filesystem
 # load_path: ./gpt-125m/checkpoints/latest-rank{rank}.pt

--- a/llm/yamls/gpt-125m-demo.yaml
+++ b/llm/yamls/gpt-125m-demo.yaml
@@ -29,7 +29,7 @@ train_loader:
     name: streaming_pubmed
     remote: *data_remote
     local: *data_local
-    split: val
+    split: train
     tokenizer_name: *tokenizer_name
     max_seq_len: *max_seq_len
     group_method: concat


### PR DESCRIPTION
This PR adds support for a streaming PubMed dataset, to which Jason has access.

You can verify that the dataset is accessible and producing samples as desired by running `python llm/data_pubmed.py [remote_s3_uri] /tmp/mds-cache/pumbed`. This will build a streaming dataloader and iterate over a few samples of the `val` splite, and print out to console.

I've also edited `yamls/gpt-125m-demo.yaml` so that it's better for WandB artifact logging and resumption. Important -- do not pass any `name:` field to the WandB logger itself when logging, it's better to pass it top level to the Trainer as `run_name`. This ensures that all formatted names and logger endpoints use the same value.